### PR TITLE
Inappropriate example redirect URL

### DIFF
--- a/iOS-NestDK/Constants.m
+++ b/iOS-NestDK/Constants.m
@@ -27,6 +27,6 @@ NSString * const NestCurrentAPIDomain = @"home.nest.com";
 
 NSString * const NestState = @"SOMESTATE";
 
-NSString * const RedirectURL = @"http://xxx.com";
+NSString * const RedirectURL = @"http://www.example.com";
 
 


### PR DESCRIPTION
"http://xxx.com" is a valid URL and points to a website you very likely did not intend to link to.