### PR TITLE
Fixing Error on Thermostat Update when thermostat has no fan

### DIFF
--- a/iOS-NestDK/NestThermostatManager.m
+++ b/iOS-NestDK/NestThermostatManager.m
@@ -82,7 +82,11 @@
     NSMutableDictionary *values = [[NSMutableDictionary alloc] init];
     
     [values setValue:[NSNumber numberWithInteger:thermostat.targetTemperatureF] forKey:TARGET_TEMPERATURE_F];
-    [values setValue:[NSNumber numberWithBool:thermostat.fanTimerActive] forKey:FAN_TIMER_ACTIVE];
+    
+    //Check if the thermostat has a fan before setting the fanTimerActive value
+    if (thermostat.hasFan) {
+        [values setValue:[NSNumber numberWithBool:thermostat.fanTimerActive] forKey:FAN_TIMER_ACTIVE];
+    }
     
     [[FirebaseManager sharedManager] setValues:values forURL:[NSString stringWithFormat:@"%@/%@/", THERMOSTAT_PATH, thermostat.thermostatId]];
     


### PR DESCRIPTION
If the current thermostat has no fan, we need to check if thermostat
has a fan before setting the fanTimerActive value.  If this value is
posted to the api and the thermostat does not have a fan, then the
error below is received.

https://developers.nest.com/documentation/cloud/error-messages#no-hvac-f
an

Must have been coded by someone in a hotel climate than I :)